### PR TITLE
Fix seed field not working

### DIFF
--- a/src/main/java/fr/rader/oldworldmenu/MoreWorldOptionsComponent.java
+++ b/src/main/java/fr/rader/oldworldmenu/MoreWorldOptionsComponent.java
@@ -45,6 +45,7 @@ public class MoreWorldOptionsComponent {
 
         this.seedField = new TextFieldWidget(textRenderer, this.halfWidth - 100, 60, 200, 20, SEED_LABEL);
         this.seedField.setText(this.worldCreator.getSeed());
+        this.seedField.setChangedListener(this.worldCreator::setSeed);
 
         int leftColumnX = this.halfWidth - 155;
         int rightColumnX = this.halfWidth + 5;


### PR DESCRIPTION
Requires listener to be present as otherwise defined seeds become random instead.